### PR TITLE
fix: register missing caches and standardize error response format

### DIFF
--- a/src/main/java/com/example/project_tracker/config/CacheConfig.java
+++ b/src/main/java/com/example/project_tracker/config/CacheConfig.java
@@ -1,0 +1,21 @@
+package com.example.project_tracker.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(
+                "projects",       // Must match the name in @Cacheable("projects")
+                "projectById",    // Also used in getProjectById
+                "tasks"           // Used in @CacheEvict
+        );
+    }
+}

--- a/src/main/java/com/example/project_tracker/security/handlers/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/project_tracker/security/handlers/CustomAccessDeniedHandler.java
@@ -2,69 +2,46 @@ package com.example.project_tracker.security.handlers;
 
 import com.example.project_tracker.annotations.Auditable;
 import com.example.project_tracker.service.AuditLogService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
- * Custom implementation of {@link AccessDeniedHandler} that returns a JSON response
- * when a user is authenticated but lacks necessary permissions.
- * <p>
- * This handler also triggers auditing via the {@link Auditable} annotation and returns
- * a structured 403 Forbidden error in JSON format.
+ * Custom implementation of {@link AccessDeniedHandler} that sends a standardized 403 Forbidden
+ * response when access is denied for an authenticated user.
  */
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private final AuditLogService auditLogService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    /**
-     * Constructs the access denied handler with a dependency on {@link AuditLogService}.
-     *
-     * @param auditLogService the audit logging service used for tracking security events
-     */
     public CustomAccessDeniedHandler(AuditLogService auditLogService) {
         this.auditLogService = auditLogService;
     }
 
-    /**
-     * Handles access denial by returning a structured JSON response with HTTP 403 status.
-     * Also triggers auditing of the access denial.
-     *
-     * @param request                the current HTTP request
-     * @param response               the HTTP response to be written
-     * @param accessDeniedException the exception indicating access was denied
-     * @throws IOException if writing the response fails
-     */
     @Auditable(actionType = "ACCESS_DENIED", entityType = "Security")
     @Override
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
 
-        if (response.isCommitted()) {
-            return;
-        }
-
-        // Build structured JSON error response
-        Map<String, Object> error = new HashMap<>();
-        error.put("timestamp", LocalDateTime.now());
-        error.put("status", HttpStatus.FORBIDDEN.value());
-        error.put("message", "Access denied: " + accessDeniedException.getMessage());
-
-        response.setStatus(HttpStatus.FORBIDDEN.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        objectMapper.writeValue(response.getWriter(), error);
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write(String.format(
+                """
+                {
+                    "message": "Authorization failed: %s",
+                    "timestamp": "%s",
+                    "status": 403
+                }
+                """,
+                accessDeniedException.getMessage(),
+                java.time.Instant.now().toString()
+        ));
     }
 }

--- a/src/main/java/com/example/project_tracker/security/handlers/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/project_tracker/security/handlers/CustomAuthenticationEntryPoint.java
@@ -14,36 +14,35 @@ import java.io.IOException;
  * Custom implementation of {@link AuthenticationEntryPoint} that handles unauthorized access attempts.
  * <p>
  * This is triggered when a user tries to access a protected resource without proper authentication.
- * It logs the incident (via the {@link Auditable} annotation) and sends a 401 Unauthorized HTTP response.
+ * It logs the incident (via the {@link Auditable} annotation) and sends a standardized 401 Unauthorized response.
  */
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final AuditLogService auditLogService;
 
-    /**
-     * Constructs the custom authentication entry point with dependency injection for auditing.
-     *
-     * @param auditLogService the service responsible for persisting audit logs
-     */
     public CustomAuthenticationEntryPoint(AuditLogService auditLogService) {
         this.auditLogService = auditLogService;
     }
 
-    /**
-     * Handles an unauthorized request by returning a 401 error and triggering auditing.
-     *
-     * @param request       the incoming HTTP request
-     * @param response      the HTTP response to be sent
-     * @param authException the exception that caused the authentication failure
-     * @throws IOException if an input or output error occurs
-     */
     @Auditable(actionType = "ACCESS_DENIED", entityType = "Security")
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write(String.format(
+                """
+                {
+                    "message": "Authentication failed: %s",
+                    "timestamp": "%s",
+                    "status": 401
+                }
+                """,
+                authException.getMessage(),
+                java.time.Instant.now().toString()
+        ));
     }
 }


### PR DESCRIPTION
- Registered 'projects', 'projectById', and 'tasks' caches to resolve runtime errors in ProjectService.
- Ensured consistent JSON error responses across unauthorized and forbidden access handlers.
